### PR TITLE
Logs written the top of the file by default

### DIFF
--- a/Source/Dna.Framework/Logging/File/FileLogger.cs
+++ b/Source/Dna.Framework/Logging/File/FileLogger.cs
@@ -129,8 +129,25 @@ namespace Dna
                 if (!Directory.Exists(mDirectory))
                     Directory.CreateDirectory(mDirectory);
 
-                // Write the message to the file
-                File.AppendAllText(mFilePath, output);
+                // If log at top is set to true...
+                if (mConfiguration.LogAtTop)
+                {
+                    // Open the file
+                    var fileStream = File.Open(mFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+
+                    // Set the current position to 0
+                    fileStream.Seek(0, SeekOrigin.Begin);
+
+                    // Initialize new stream writer
+                    var streamWriter = new StreamWriter(fileStream);
+
+                    // Write the message to the file
+                    streamWriter.WriteAsync(output);
+                }
+                // Else...
+                else
+                    // Write the message to the file
+                    File.AppendAllText(mFilePath, output);
             }
         }
     }

--- a/Source/Dna.Framework/Logging/File/FileLoggerConfiguration.cs
+++ b/Source/Dna.Framework/Logging/File/FileLoggerConfiguration.cs
@@ -19,6 +19,11 @@ namespace Dna
         /// </summary>
         public bool LogTime { get; set; } = true;
 
+        /// <summary>
+        /// Whether to display latest logs at the top of the file
+        /// </summary>
+        public bool LogAtTop { get; set; } = true;
+
         #endregion
     }
 }

--- a/Source/Dna.Framework/Logging/File/FileLoggerExtensions.cs
+++ b/Source/Dna.Framework/Logging/File/FileLoggerExtensions.cs
@@ -32,14 +32,15 @@ namespace Dna
         /// </summary>
         /// <param name="construction">The construction</param>
         /// <param name="logPath">The path of the file to log to</param>
+        /// <param name="logTop">Whether to display latest logs at the top of the file</param>
         /// <returns></returns>
-        public static FrameworkConstruction AddFileLogger(this FrameworkConstruction construction, string logPath = "log.txt")
+        public static FrameworkConstruction AddFileLogger(this FrameworkConstruction construction, string logPath = "log.txt", bool logTop = true)
         {
             // Make use of AddLogging extension
             construction.Services.AddLogging(options =>
             {
                 // Add file logger
-                options.AddFile(logPath);
+                options.AddFile(logPath, new FileLoggerConfiguration { LogAtTop = logTop });
             });
             
             // Chain the construction


### PR DESCRIPTION
Use FileStream and StreamWriter to write new logs to the top of a log file. Uses boolean which is true by default.